### PR TITLE
Add documentation of binary modification

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -11,3 +11,24 @@ Download the latest [Release](https://github.com/protojure/protoc-plugin/release
 sudo curl -L https://github.com/protojure/protoc-plugin/releases/download/v2.0.0/protoc-gen-clojure --output /usr/local/bin/protoc-gen-clojure
 sudo chmod +x /usr/local/bin/protoc-gen-clojure
 ```
+
+### Usage with non-`protoc` clients
+To use this plugin with other build systems (such as [buf](https://github.com/bufbuild/buf)), you'll need to modify the binary, as the binary is actually a shell wrapper around a `.jar` file. If you see an error that looks like this:
+
+```console
+Failure: plugin clojure: fork/exec /Users/me/.local/bin/protoc-gen-clojure: exec format error
+```
+It's because of this shell wrapper.
+
+In order for `exec` calls to work properly (on a \*nix system), you'll need to prepend a hashbang to the shell block. An example of how to do this:
+
+```sh
+cd /path/to/containing/folder
+mv protoc-gen-clojure protoc-gen-clojure-other
+echo "#!/bin/sh" > protoc-gen-clojure
+cat protoc-gen-clojure-other >> protoc-gen-clojure
+chmod +x protoc-gen-clojure
+rm protoc-gen-clojure-other
+```
+
+Note that your editor may reformat the binary in such a way that it doesn't work anymore; hence the above approach.


### PR DESCRIPTION
Closes protojure/protoc-plugin#66
## Description
See protojure/protoc-plugin#66. `lein-bin` produces a binary that doesn't work well with `fork` or `exec` calls. Adding a hashbang is sufficient to get it working with a system like `buf`, but that is non-obvious. Adding this to the install documentation should help avoid people stumbling on this in the future, and having a reference to the error should help people google for it.

## Changes
* Add bit to documentation about adding a hashbang to the binary if necessary

Signed-off-by: Tanner <tstirrat@gmail.com>